### PR TITLE
Update extension to use new version of SymfonyMockerContainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ phpunit.xml
 vendor
 composer.lock
 composer.phar
+bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+
+before_script:
+  - wget -nc http://getcomposer.org/composer.phar
+  - php composer.phar install
+
+script: bin/phpspec --no-ansi --format=pretty
+
+notifications:
+  email:
+    - jakub+ci@zalas.pl
+    - cakper+ci@gmail.com
+  irc: "irc.freenode.org#symfony-pl"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
   - wget -nc http://getcomposer.org/composer.phar
   - php composer.phar install
 
-script: bin/phpspec --no-ansi --format=pretty
+script: bin/phpspec run --no-ansi --format=pretty
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 Behat extension for mocking services defined in the Symfony2 dependency
 injection container.
 
-Internally it uses [Mockery](https://github.com/padraic/mockery) and
-[SymfonyMockerContainer](https://github.com/PolishSymfonyCommunity/SymfonyMockerContainer).
+Internally it uses [SymfonyMockerContainer](https://github.com/PolishSymfonyCommunity/SymfonyMockerContainer)
+and [Prophecy](https://github.com/phpspec/prophecy) or [Mockery](https://github.com/padraic/mockery).
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "polishsymfonycommunity/symfony2-mocker-extension",
     "description": "Behat extension for mocking services defined in the Symfony2 dependency injection container.",
-    "keywords": ["behat", "prophecy", "mock", "bdd", "tdd", "test"],
+    "keywords": ["behat", "prophecy", "mockery", "mock", "bdd", "tdd", "test"],
     "homepage": "http://symfonylab.pl",
     "license": "MIT",
     "authors": [
@@ -39,6 +39,10 @@
         "phpspec/prophecy": ">=1.0.0",
         "mockery/mockery":  ">=0.7.0",
         "behat/mink-browserkit-driver": "*"
+    },
+    "suggest": {
+        "phpspec/prophecy": "Enables Prophecy mocking framework",
+        "mockery/mockery": "Enables Mockery framework"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "symfony/event-dispatcher": "*",
         "symfony/http-kernel": "*",
 
-        "polishsymfonycommunity/symfony-mocker-container": "~2.0.0"
+        "polishsymfonycommunity/symfony-mocker-container": ">=1.1.0"
     },
     "require-dev": {
         "phpspec/phpspec": "2.0.*@dev",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "polishsymfonycommunity/symfony-mocker-container": "*"
     },
     "require-dev": {
-        "phpspec/phpspec": "2.0.*@dev"
+        "phpspec/phpspec": "2.0.*@dev",
+        "behat/mink-browserkit-driver": "*"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -32,12 +32,12 @@
         "symfony/event-dispatcher": "*",
         "symfony/http-kernel": "*",
 
-        "phpspec/prophecy": ">=1.0.0",
-
-        "polishsymfonycommunity/symfony-mocker-container": "*"
+        "polishsymfonycommunity/symfony-mocker-container": "~2.0.0"
     },
     "require-dev": {
         "phpspec/phpspec": "2.0.*@dev",
+        "phpspec/prophecy": ">=1.0.0",
+        "mockery/mockery":  ">=0.7.0",
         "behat/mink-browserkit-driver": "*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "polishsymfonycommunity/symfony2-mocker-extension",
     "description": "Behat extension for mocking services defined in the Symfony2 dependency injection container.",
-    "keywords": ["behat", "mockery", "mock", "bdd", "tdd", "test"],
+    "keywords": ["behat", "prophecy", "mock", "bdd", "tdd", "test"],
     "homepage": "http://symfonylab.pl",
     "license": "MIT",
     "authors": [
@@ -11,27 +11,40 @@
             "homepage": "http://www.zalas.eu"
         },
         {
+            "name": "Kacper Gunia",
+            "email": "cakper@gmail.com",
+            "homepage": "http://cakper.net/"
+        },
+        {
             "name": "Polish Symfony Community",
             "homepage": "http://symfonylab.pl"
         }
     ],
     "require": {
-        "php":                          ">=5.3.2",
+        "php": ">=5.3.2",
 
-        "behat/behat":                  ">=2.4",
-        "behat/mink":                   ">=1.4",
-        "behat/symfony2-extension":     "*",
+        "behat/behat": ">=2.4",
+        "behat/mink": ">=1.4",
+        "behat/symfony2-extension": "*",
 
-        "symfony/config":               "*",
+        "symfony/config": "*",
         "symfony/dependency-injection": "*",
-        "symfony/event-dispatcher":     "*",
-        "symfony/http-kernel":          "*",
+        "symfony/event-dispatcher": "*",
+        "symfony/http-kernel": "*",
 
-        "mockery/mockery":              ">=0.7.0",
+        "phpspec/prophecy": ">=1.0.0",
 
         "polishsymfonycommunity/symfony-mocker-container": "*"
     },
+    "require-dev": {
+        "phpspec/phpspec": "2.0.*@dev"
+    },
     "autoload": {
-        "psr-0": { "PSS\\Behat\\Symfony2MockerExtension": "src/" }
+        "psr-0": {
+            "PSS\\Behat\\Symfony2MockerExtension": "src/"
+        }
+    },
+    "config": {
+        "bin-dir": "bin"
     }
 }

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -54,7 +54,7 @@ The easiest way to keep your suite updated is to use `Composer <http://getcompos
             "require": {
                 ...
 
-                "polishsymfonycommunity/symfony2-mocker-extension": "~2.0.0",
+                "polishsymfonycommunity/symfony2-mocker-extension": ">=1.1.0",
                 "phpspec/prophecy":                                 ">=1.0.0", // For Prophecy integration
                 "mockery/mockery":                                  ">=0.7.0"  // For Mockery integration
             }

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -4,12 +4,12 @@ Symfony2 Mocker Extension
 Behat extension for mocking services defined in the Symfony2 dependency
 injection container.
 
-Internally it uses `Mockery <https://github.com/padraic/mockery>`_ and
-`SymfonyMockerContainer <https://github.com/PolishSymfonyCommunity/SymfonyMockerContainer>`_.
+Internally it uses `SymfonyMockerContainer <https://github.com/PolishSymfonyCommunity/SymfonyMockerContainer>`_
+and `Prophecy <https://github.com/phpspec/prophecy>`_ or `Mockery <https://github.com/padraic/mockery>`_.
 
     .. note::
 
-        Mocking services in acceptance tests is not always the best option, 
+        Mocking services in acceptance tests is not always the best option,
         but sometimes it is a necessity. Especially, if we don't have a possibility to use
         the service in a test mode to prevent interactions with the production environment.
 
@@ -46,7 +46,7 @@ Through Composer
 
 The easiest way to keep your suite updated is to use `Composer <http://getcomposer.org>`_:
 
-1. Define the dependencies in your `composer.json`:
+1. Choose and define the dependencies in your `composer.json`:
 
     .. code-block:: js
 
@@ -54,7 +54,9 @@ The easiest way to keep your suite updated is to use `Composer <http://getcompos
             "require": {
                 ...
 
-                "polishsymfonycommunity/symfony2-mocker-extension": "*"
+                "polishsymfonycommunity/symfony2-mocker-extension": "~2.0.0",
+                "phpspec/prophecy":                                 ">=1.0.0", // For Prophecy integration
+                "mockery/mockery":                                  ">=0.7.0"  // For Mockery integration
             }
         }
 
@@ -90,7 +92,8 @@ The base container class for the test environment needs to be replaced in
         protected function getContainerBaseClass()
         {
             if ('test' == $this->environment) {
-                return '\PSS\SymfonyMockerContainer\DependencyInjection\MockerContainer';
+                return '\PSS\SymfonyMockerContainer\DependencyInjection\ProphecyContainer'; // For Prophecy integration
+//              return '\PSS\SymfonyMockerContainer\DependencyInjection\MockeryContainer';  // For Mockery integration
             }
 
             return parent::getContainerBaseClass();
@@ -146,10 +149,10 @@ and mocker will be injected into your context automatically:
              */
             public function crmApiIsAvailable()
             {
+                // All mock examples are using Prophecy
                 $this->mocker->mockService('crm.client', 'PSS\Crm\Client')
-                    ->shouldReceive('send')
-                    ->once()
-                    ->andReturn(true);
+                    ->send()
+                    ->willReturn(true);
             }
         }
 
@@ -175,9 +178,8 @@ and call the mocker with the ``mockService()`` method:
             public function crmApiIsAvailable()
             {
                 $this->mockService('crm.client', 'PSS\Crm\Client')
-                    ->shouldReceive('send')
-                    ->once()
-                    ->andReturn(true);
+                    ->send()
+                    ->willReturn(true);
             }
         }
 
@@ -269,9 +271,8 @@ One way of solving this issue is to mock the service and only verify if it was c
             {
                 $this->getMainContext()->getSubContext('container')
                     ->mockService('crm.client', 'PSS\Crm\Client')
-                    ->shouldReceive('send')
-                    ->once()
-                    ->andReturn(true);
+                    ->send()
+                    ->willReturn(true);
             }
 
             /**

--- a/spec/PSS/Behat/Symfony2MockerExtension/Context/Initializer/ServiceMockerInitializerSpec.php
+++ b/spec/PSS/Behat/Symfony2MockerExtension/Context/Initializer/ServiceMockerInitializerSpec.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace spec\PSS\Behat\Symfony2MockerExtension\Context\Initializer;
+
+use Behat\Behat\Context\ContextInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use PSS\Behat\Symfony2MockerExtension\Context\ServiceMockerAwareInterface;
+use PSS\Behat\Symfony2MockerExtension\ServiceMocker;
+use Symfony\Component\EventDispatcher\Event;
+
+class ServiceMockerInitializerSpec extends ObjectBehavior
+{
+    function let(ServiceMocker $serviceMocker)
+    {
+        $this->beConstructedWith($serviceMocker);
+    }
+
+    function it_subscribes_behat_events()
+    {
+        $this->getSubscribedEvents()->shouldReturn(
+            array(
+                'afterScenario'       => 'verifyPendingExpectations',
+                'afterOutlineExample' => 'verifyPendingExpectations'
+            )
+        );
+    }
+
+    function it_verifies_expectations(Event $event, ServiceMocker $serviceMocker)
+    {
+        $this->verifyPendingExpectations($event);
+        $serviceMocker->verifyPendingExpectations()->shouldHaveBeenCalled();
+    }
+
+    function it_supports_service_mocker_aware_context(ServiceMockerAwareContext $context)
+    {
+        $this->supports($context)->shouldReturn(true);
+    }
+
+    function it_doesnt_support_other_contexts(ContextInterface $context)
+    {
+        $this->supports($context)->shouldReturn(false);
+    }
+
+    function it_initialises_context_with_service_mocker(ServiceMockerAwareContext $context, ServiceMocker $serviceMocker)
+    {
+        $this->initialize($context);
+        $context->setServiceMocker($serviceMocker)->shouldHaveBeenCalled();
+    }
+}
+
+class ServiceMockerAwareContext implements ContextInterface, ServiceMockerAwareInterface
+{
+    public function setServiceMocker(ServiceMocker $serviceMocker){}
+}

--- a/spec/PSS/Behat/Symfony2MockerExtension/Context/Initializer/ServiceMockerInitializerSpec.php
+++ b/spec/PSS/Behat/Symfony2MockerExtension/Context/Initializer/ServiceMockerInitializerSpec.php
@@ -28,8 +28,8 @@ class ServiceMockerInitializerSpec extends ObjectBehavior
 
     function it_verifies_expectations(Event $event, ServiceMocker $serviceMocker)
     {
+        $serviceMocker->verifyPendingExpectations()->shouldBeCalled();
         $this->verifyPendingExpectations($event);
-        $serviceMocker->verifyPendingExpectations()->shouldHaveBeenCalled();
     }
 
     function it_supports_service_mocker_aware_context(ServiceMockerAwareContext $context)
@@ -44,8 +44,8 @@ class ServiceMockerInitializerSpec extends ObjectBehavior
 
     function it_initialises_context_with_service_mocker(ServiceMockerAwareContext $context, ServiceMocker $serviceMocker)
     {
+        $context->setServiceMocker($serviceMocker)->shouldBeCalled();
         $this->initialize($context);
-        $context->setServiceMocker($serviceMocker)->shouldHaveBeenCalled();
     }
 }
 

--- a/spec/PSS/Behat/Symfony2MockerExtension/ServiceMockerSpec.php
+++ b/spec/PSS/Behat/Symfony2MockerExtension/ServiceMockerSpec.php
@@ -76,14 +76,14 @@ class ServiceMockerSpec extends ObjectBehavior
         $this->verifyPendingExpectations();
     }
 
-    function it_proxy_mocks_to_container(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, MockerContainer $mockerContainer, Prophet $service)
+    function it_proxy_mocks_to_container(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, MockerContainer $mockerContainer)
     {
         $mink->getSession()->willReturn($session);
         $session->getDriver()->willreturn($driver);
         $kernel->getContainer()->willReturn($mockerContainer);
 
-        $mockerContainer->mock('service_id', $service)->shouldBeCalled();
+        $mockerContainer->mock('service_id', '\StdClass')->shouldBeCalled();
 
-        $this->mockService('service_id', $service);
+        $this->mockService('service_id', '\StdClass');
     }
 }

--- a/spec/PSS/Behat/Symfony2MockerExtension/ServiceMockerSpec.php
+++ b/spec/PSS/Behat/Symfony2MockerExtension/ServiceMockerSpec.php
@@ -7,6 +7,7 @@ use Behat\Mink\Session;
 use Behat\Symfony2Extension\Driver\KernelDriver;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Prophecy\Prophet;
 use PSS\SymfonyMockerContainer\DependencyInjection\MockerContainer;
 use Symfony\Component\DependencyInjection\Container;
@@ -47,7 +48,7 @@ class ServiceMockerSpec extends ObjectBehavior
         $this->shouldThrow($logicException)->duringGetMockerContainer();
     }
 
-    function it_verifies_service_expectation_by_id(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, MockerContainer $mockerContainer, Prophet $service)
+    function it_verifies_service_expectation_by_id(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, MockerContainer $mockerContainer, ObjectProphecy $service)
     {
         $mink->getSession()->willReturn($session);
         $session->getDriver()->willreturn($driver);
@@ -56,10 +57,10 @@ class ServiceMockerSpec extends ObjectBehavior
 
         $this->verifyServiceExpectationsById('service_id');
 
-        $service->checkPredictions()->shouldHaveBeenCalled();
+        $service->checkProphecyMethodsPredictions()->shouldHaveBeenCalled();
     }
 
-    function it_verifies_all_pending_expectations(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, MockerContainer $mockerContainer, Prophet $service1, Prophet $service2)
+    function it_verifies_all_pending_expectations(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, MockerContainer $mockerContainer, ObjectProphecy $service1, ObjectProphecy $service2)
     {
         $services = array('service1' => $service1, 'service2' => $service2);
 
@@ -70,8 +71,8 @@ class ServiceMockerSpec extends ObjectBehavior
 
         $mockerContainer->unmock('service1')->shouldBeCalled();
         $mockerContainer->unmock('service2')->shouldBeCalled();
-        $service1->checkPredictions()->shouldBeCalled();
-        $service2->checkPredictions()->shouldBeCalled();
+        $service1->checkProphecyMethodsPredictions()->shouldBeCalled();
+        $service2->checkProphecyMethodsPredictions()->shouldBeCalled();
 
         $this->verifyPendingExpectations();
     }

--- a/spec/PSS/Behat/Symfony2MockerExtension/ServiceMockerSpec.php
+++ b/spec/PSS/Behat/Symfony2MockerExtension/ServiceMockerSpec.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace spec\PSS\Behat\Symfony2MockerExtension;
+
+use Behat\Mink\Mink;
+use Behat\Mink\Session;
+use Behat\Symfony2Extension\Driver\KernelDriver;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Prophecy\Prophet;
+use PSS\SymfonyMockerContainer\DependencyInjection\MockerContainer;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class ServiceMockerSpec extends ObjectBehavior
+{
+    function let(KernelInterface $kernel, Mink $mink)
+    {
+        $this->beConstructedWith($kernel, $mink);
+    }
+
+    function it_returns_mocker_container_when_present(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, MockerContainer $mockerContainer)
+    {
+        $mink->getSession()->willReturn($session);
+        $session->getDriver()->willreturn($driver);
+        $kernel->getContainer()->willReturn($mockerContainer);
+
+        $this->getMockerContainer()->shouldReturn($mockerContainer);
+    }
+
+    function it_throws_an_exception_if_container_is_not_an_instance_of_mocker_container(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, Container $mockerContainer)
+    {
+        $mink->getSession()->willReturn($session);
+        $session->getDriver()->willreturn($driver);
+        $kernel->getContainer()->willReturn($mockerContainer);
+
+        $logicException = new \LogicException('Container is not able to mock the services');
+        $this->shouldThrow($logicException)->duringGetMockerContainer();
+    }
+
+    function it_throws_an_exception_if_driver_is_not_an_instance_of_kernel_container(Mink $mink, Session $session)
+    {
+        $mink->getSession()->willReturn($session);
+        $session->getDriver()->willreturn(new \StdClass);
+
+        $logicException = new \LogicException('Session has no access to client container');
+        $this->shouldThrow($logicException)->duringGetMockerContainer();
+    }
+
+    function it_verifies_service_expectation_by_id(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, MockerContainer $mockerContainer, Prophet $service)
+    {
+        $mink->getSession()->willReturn($session);
+        $session->getDriver()->willreturn($driver);
+        $kernel->getContainer()->willReturn($mockerContainer);
+        $mockerContainer->get('service_id')->willReturn($service);
+
+        $this->verifyServiceExpectationsById('service_id');
+
+        $service->checkPredictions()->shouldHaveBeenCalled();
+    }
+
+    function it_verifies_all_pending_expectations(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, MockerContainer $mockerContainer, Prophet $service1, Prophet $service2)
+    {
+        $services = array('service1' => $service1, 'service2' => $service2);
+
+        $mink->getSession()->willReturn($session);
+        $session->getDriver()->willreturn($driver);
+        $kernel->getContainer()->willReturn($mockerContainer);
+        $mockerContainer->getMockedServices()->willReturn($services);
+
+        $mockerContainer->unmock('service1')->shouldBeCalled();
+        $mockerContainer->unmock('service2')->shouldBeCalled();
+        $service1->checkPredictions()->shouldBeCalled();
+        $service2->checkPredictions()->shouldBeCalled();
+
+        $this->verifyPendingExpectations();
+    }
+
+    function it_proxy_mocks_to_container(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, MockerContainer $mockerContainer, Prophet $service)
+    {
+        $mink->getSession()->willReturn($session);
+        $session->getDriver()->willreturn($driver);
+        $kernel->getContainer()->willReturn($mockerContainer);
+
+        $mockerContainer->mock('service_id', $service)->shouldBeCalled();
+
+        $this->mockService('service_id', $service);
+    }
+}

--- a/spec/PSS/Behat/Symfony2MockerExtension/ServiceMockerSpec.php
+++ b/spec/PSS/Behat/Symfony2MockerExtension/ServiceMockerSpec.php
@@ -20,7 +20,7 @@ class ServiceMockerSpec extends ObjectBehavior
     function it_returns_mocker_container_when_present(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, MockerContainerInterface $mockerContainer)
     {
         $mink->getSession()->willReturn($session);
-        $session->getDriver()->willreturn($driver);
+        $session->getDriver()->willReturn($driver);
         $kernel->getContainer()->willReturn($mockerContainer);
 
         $this->getMockerContainer()->shouldReturn($mockerContainer);
@@ -29,7 +29,7 @@ class ServiceMockerSpec extends ObjectBehavior
     function it_throws_an_exception_if_container_is_not_an_instance_of_mocker_container(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, ContainerInterface $mockerContainer)
     {
         $mink->getSession()->willReturn($session);
-        $session->getDriver()->willreturn($driver);
+        $session->getDriver()->willReturn($driver);
         $kernel->getContainer()->willReturn($mockerContainer);
 
         $logicException = new \LogicException('Container is not able to mock the services');
@@ -39,7 +39,7 @@ class ServiceMockerSpec extends ObjectBehavior
     function it_throws_an_exception_if_driver_is_not_an_instance_of_kernel_container(Mink $mink, Session $session)
     {
         $mink->getSession()->willReturn($session);
-        $session->getDriver()->willreturn(new \StdClass);
+        $session->getDriver()->willReturn(new \StdClass);
 
         $logicException = new \LogicException('Session has no access to client container');
         $this->shouldThrow($logicException)->duringGetMockerContainer();
@@ -48,7 +48,7 @@ class ServiceMockerSpec extends ObjectBehavior
     function it_verifies_service_expectation_by_id(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, MockerContainerInterface $mockerContainer)
     {
         $mink->getSession()->willReturn($session);
-        $session->getDriver()->willreturn($driver);
+        $session->getDriver()->willReturn($driver);
         $kernel->getContainer()->willReturn($mockerContainer);
 
         $mockerContainer->verifyServiceExpectationsById('service_id')->shouldBeCalled();
@@ -61,7 +61,7 @@ class ServiceMockerSpec extends ObjectBehavior
         $services = array('service1' => new \StdClass, 'service2' => new \StdClass);
 
         $mink->getSession()->willReturn($session);
-        $session->getDriver()->willreturn($driver);
+        $session->getDriver()->willReturn($driver);
         $kernel->getContainer()->willReturn($mockerContainer);
         $mockerContainer->getMockedServices()->willReturn($services);
 
@@ -76,11 +76,11 @@ class ServiceMockerSpec extends ObjectBehavior
     function it_proxy_mocks_to_container(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, MockerContainerInterface $mockerContainer)
     {
         $mink->getSession()->willReturn($session);
-        $session->getDriver()->willreturn($driver);
+        $session->getDriver()->willReturn($driver);
         $kernel->getContainer()->willReturn($mockerContainer);
 
-        $mockerContainer->mock('service_id', '\StdClass')->shouldBeCalled();
+        $mockerContainer->mock('service_id', '\stdClass')->shouldBeCalled();
 
-        $this->mockService('service_id', '\StdClass');
+        $this->mockService('service_id', '\stdClass');
     }
 }

--- a/spec/PSS/Behat/Symfony2MockerExtension/ServiceMockerSpec.php
+++ b/spec/PSS/Behat/Symfony2MockerExtension/ServiceMockerSpec.php
@@ -6,11 +6,8 @@ use Behat\Mink\Mink;
 use Behat\Mink\Session;
 use Behat\Symfony2Extension\Driver\KernelDriver;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
-use Prophecy\Prophecy\ObjectProphecy;
-use Prophecy\Prophet;
-use PSS\SymfonyMockerContainer\DependencyInjection\MockerContainer;
-use Symfony\Component\DependencyInjection\Container;
+use PSS\SymfonyMockerContainer\DependencyInjection\MockerContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 class ServiceMockerSpec extends ObjectBehavior
@@ -20,7 +17,7 @@ class ServiceMockerSpec extends ObjectBehavior
         $this->beConstructedWith($kernel, $mink);
     }
 
-    function it_returns_mocker_container_when_present(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, MockerContainer $mockerContainer)
+    function it_returns_mocker_container_when_present(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, MockerContainerInterface $mockerContainer)
     {
         $mink->getSession()->willReturn($session);
         $session->getDriver()->willreturn($driver);
@@ -29,7 +26,7 @@ class ServiceMockerSpec extends ObjectBehavior
         $this->getMockerContainer()->shouldReturn($mockerContainer);
     }
 
-    function it_throws_an_exception_if_container_is_not_an_instance_of_mocker_container(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, Container $mockerContainer)
+    function it_throws_an_exception_if_container_is_not_an_instance_of_mocker_container(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, ContainerInterface $mockerContainer)
     {
         $mink->getSession()->willReturn($session);
         $session->getDriver()->willreturn($driver);
@@ -48,36 +45,35 @@ class ServiceMockerSpec extends ObjectBehavior
         $this->shouldThrow($logicException)->duringGetMockerContainer();
     }
 
-    function it_verifies_service_expectation_by_id(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, MockerContainer $mockerContainer, ObjectProphecy $service)
+    function it_verifies_service_expectation_by_id(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, MockerContainerInterface $mockerContainer)
     {
         $mink->getSession()->willReturn($session);
         $session->getDriver()->willreturn($driver);
         $kernel->getContainer()->willReturn($mockerContainer);
-        $mockerContainer->get('service_id')->willReturn($service);
+
+        $mockerContainer->verifyServiceExpectationsById('service_id')->shouldBeCalled();
 
         $this->verifyServiceExpectationsById('service_id');
-
-        $service->checkProphecyMethodsPredictions()->shouldHaveBeenCalled();
     }
 
-    function it_verifies_all_pending_expectations(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, MockerContainer $mockerContainer, ObjectProphecy $service1, ObjectProphecy $service2)
+    function it_verifies_all_pending_expectations(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, MockerContainerInterface $mockerContainer)
     {
-        $services = array('service1' => $service1, 'service2' => $service2);
+        $services = array('service1' => new \StdClass, 'service2' => new \StdClass);
 
         $mink->getSession()->willReturn($session);
         $session->getDriver()->willreturn($driver);
         $kernel->getContainer()->willReturn($mockerContainer);
         $mockerContainer->getMockedServices()->willReturn($services);
 
+        $mockerContainer->verifyServiceExpectationsById('service1')->shouldBeCalled();
+        $mockerContainer->verifyServiceExpectationsById('service2')->shouldBeCalled();
         $mockerContainer->unmock('service1')->shouldBeCalled();
         $mockerContainer->unmock('service2')->shouldBeCalled();
-        $service1->checkProphecyMethodsPredictions()->shouldBeCalled();
-        $service2->checkProphecyMethodsPredictions()->shouldBeCalled();
 
         $this->verifyPendingExpectations();
     }
 
-    function it_proxy_mocks_to_container(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, MockerContainer $mockerContainer)
+    function it_proxy_mocks_to_container(KernelInterface $kernel, Mink $mink, Session $session, KernelDriver $driver, MockerContainerInterface $mockerContainer)
     {
         $mink->getSession()->willReturn($session);
         $session->getDriver()->willreturn($driver);

--- a/src/PSS/Behat/Symfony2MockerExtension/Context/Initializer/ServiceMockerInitializer.php
+++ b/src/PSS/Behat/Symfony2MockerExtension/Context/Initializer/ServiceMockerInitializer.php
@@ -40,7 +40,7 @@ class ServiceMockerInitializer implements InitializerInterface, EventSubscriberI
     /**
      * @param ContextInterface $context
      *
-     * @return bool
+     * @return boolean
      */
     public function supports(ContextInterface $context)
     {
@@ -61,8 +61,6 @@ class ServiceMockerInitializer implements InitializerInterface, EventSubscriberI
 
     /**
      * @param ScenarioEvent|OutlineEvent $event
-     *
-     * @return null
      */
     public function verifyPendingExpectations(Event $event)
     {

--- a/src/PSS/Behat/Symfony2MockerExtension/Context/Initializer/ServiceMockerInitializer.php
+++ b/src/PSS/Behat/Symfony2MockerExtension/Context/Initializer/ServiceMockerInitializer.php
@@ -4,21 +4,22 @@ namespace PSS\Behat\Symfony2MockerExtension\Context\Initializer;
 
 use Behat\Behat\Context\Initializer\InitializerInterface;
 use Behat\Behat\Context\ContextInterface;
+use Behat\Behat\Event\OutlineEvent;
+use Behat\Behat\Event\ScenarioEvent;
 use PSS\Behat\Symfony2MockerExtension\ServiceMocker;
 use PSS\Behat\Symfony2MockerExtension\Context\ServiceMockerAwareInterface;
+use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ServiceMockerInitializer implements InitializerInterface, EventSubscriberInterface
 {
     /**
-     * @var \PSS\Behat\Symfony2MockerExtension\ServiceMocker $serviceMocker
+     * @var ServiceMocker $serviceMocker
      */
     private $serviceMocker = null;
 
     /**
-     * @param \PSS\Behat\Symfony2MockerExtension\ServiceMocker $serviceMocker
-     *
-     * @return null
+     * @param ServiceMocker $serviceMocker
      */
     public function __construct(ServiceMocker $serviceMocker)
     {
@@ -26,9 +27,20 @@ class ServiceMockerInitializer implements InitializerInterface, EventSubscriberI
     }
 
     /**
-     * @param \Behat\Behat\Context\ContextInterface $context
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            'afterScenario'       => 'verifyPendingExpectations',
+            'afterOutlineExample' => 'verifyPendingExpectations'
+        );
+    }
+
+    /**
+     * @param ContextInterface $context
      *
-     * @return boolean
+     * @return bool
      */
     public function supports(ContextInterface $context)
     {
@@ -40,9 +52,7 @@ class ServiceMockerInitializer implements InitializerInterface, EventSubscriberI
     }
 
     /**
-     * @param Behat\Behat\Context\ContextInterface $context
-     *
-     * @return null
+     * @param ContextInterface $context
      */
     public function initialize(ContextInterface $context)
     {
@@ -50,22 +60,11 @@ class ServiceMockerInitializer implements InitializerInterface, EventSubscriberI
     }
 
     /**
-     * @return array
-     */
-    public static function getSubscribedEvents()
-    {
-        return array(
-            'afterScenario' => 'verifyPendingExpectations',
-            'afterOutlineExample' => 'verifyPendingExpectations'
-        );
-    }
-
-    /**
-     * @param \Behat\Behat\Event\ScenarioEvent|\Behat\Behat\Event\OutlineEvent $event
+     * @param ScenarioEvent|OutlineEvent $event
      *
      * @return null
      */
-    public function verifyPendingExpectations($event)
+    public function verifyPendingExpectations(Event $event)
     {
         $this->serviceMocker->verifyPendingExpectations();
     }

--- a/src/PSS/Behat/Symfony2MockerExtension/Context/RawServiceMockerContext.php
+++ b/src/PSS/Behat/Symfony2MockerExtension/Context/RawServiceMockerContext.php
@@ -14,6 +14,17 @@ class RawServiceMockerContext extends BehatContext implements ServiceMockerAware
     private $serviceMocker = null;
 
     /**
+     * @param $id               Service Id
+     * @param $classOrInterface Class or Interface name
+     *
+     * @return ObjectProphecy
+     */
+    public function mockService($id, $classOrInterface)
+    {
+        return $this->serviceMocker->mockService($id, $classOrInterface);
+    }
+
+    /**
      * @return ServiceMocker
      */
     protected function getServiceMocker()
@@ -27,16 +38,5 @@ class RawServiceMockerContext extends BehatContext implements ServiceMockerAware
     public function setServiceMocker(ServiceMocker $serviceMocker)
     {
         $this->serviceMocker = $serviceMocker;
-    }
-
-    /**
-     * @param $id               Service Id
-     * @param $classOrInterface Class or Interface name
-     *
-     * @return ObjectProphecy
-     */
-    public function mockService($id, $classOrInterface)
-    {
-        return $this->serviceMocker->mockService($id, $classOrInterface);
     }
 }

--- a/src/PSS/Behat/Symfony2MockerExtension/Context/RawServiceMockerContext.php
+++ b/src/PSS/Behat/Symfony2MockerExtension/Context/RawServiceMockerContext.php
@@ -9,22 +9,12 @@ use PSS\Behat\Symfony2MockerExtension\Context\ServiceMockerAwareInterface;
 class RawServiceMockerContext extends BehatContext implements ServiceMockerAwareInterface
 {
     /**
-     * @var \PSS\Behat\Symfony2MockerExtension\ServiceMocker $serviceMocker
+     * @var ServiceMocker $serviceMocker
      */
     private $serviceMocker = null;
 
     /**
-     * @param \PSS\Behat\Symfony2MockerExtension\ServiceMocker $serviceMocker
-     *
-     * @return null
-     */
-    public function setServiceMocker(ServiceMocker $serviceMocker)
-    {
-        $this->serviceMocker = $serviceMocker;
-    }
-
-    /**
-     * @return \PSS\Behat\Symfony2MockerExtension\ServiceMocker
+     * @return ServiceMocker
      */
     protected function getServiceMocker()
     {
@@ -32,7 +22,15 @@ class RawServiceMockerContext extends BehatContext implements ServiceMockerAware
     }
 
     /**
-     * @return \Mockery\Mock
+     * @param ServiceMocker $serviceMocker
+     */
+    public function setServiceMocker(ServiceMocker $serviceMocker)
+    {
+        $this->serviceMocker = $serviceMocker;
+    }
+
+    /**
+     * @return \Prophecy\Prophet
      */
     protected function mockService()
     {

--- a/src/PSS/Behat/Symfony2MockerExtension/Context/RawServiceMockerContext.php
+++ b/src/PSS/Behat/Symfony2MockerExtension/Context/RawServiceMockerContext.php
@@ -14,8 +14,8 @@ class RawServiceMockerContext extends BehatContext implements ServiceMockerAware
     private $serviceMocker = null;
 
     /**
-     * @param $id               Service Id
-     * @param $classOrInterface Class or Interface name
+     * @param string $id               Service Id
+     * @param string $classOrInterface Class or Interface name
      *
      * @return ObjectProphecy
      */

--- a/src/PSS/Behat/Symfony2MockerExtension/Context/RawServiceMockerContext.php
+++ b/src/PSS/Behat/Symfony2MockerExtension/Context/RawServiceMockerContext.php
@@ -30,10 +30,13 @@ class RawServiceMockerContext extends BehatContext implements ServiceMockerAware
     }
 
     /**
-     * @return \Prophecy\Prophet
+     * @param $id               Service Id
+     * @param $classOrInterface Class or Interface name
+     *
+     * @return ObjectProphecy
      */
-    protected function mockService()
+    public function mockService($id, $classOrInterface)
     {
-        return call_user_func_array(array($this->serviceMocker, 'mockService'), func_get_args());
+        return $this->serviceMocker->mockService($id, $classOrInterface);
     }
 }

--- a/src/PSS/Behat/Symfony2MockerExtension/Context/ServiceMockerAwareInterface.php
+++ b/src/PSS/Behat/Symfony2MockerExtension/Context/ServiceMockerAwareInterface.php
@@ -7,9 +7,9 @@ use PSS\Behat\Symfony2MockerExtension\ServiceMocker;
 interface ServiceMockerAwareInterface
 {
     /**
-     * @param \PSS\Behat\Symfony2MockerExtension\ServiceMocker $serviceMocker
+     * @param ServiceMocker $serviceMocker
      *
-     * @return null
+     * @return mixed
      */
     public function setServiceMocker(ServiceMocker $serviceMocker);
 }

--- a/src/PSS/Behat/Symfony2MockerExtension/Context/ServiceMockerAwareInterface.php
+++ b/src/PSS/Behat/Symfony2MockerExtension/Context/ServiceMockerAwareInterface.php
@@ -8,8 +8,6 @@ interface ServiceMockerAwareInterface
 {
     /**
      * @param ServiceMocker $serviceMocker
-     *
-     * @return mixed
      */
     public function setServiceMocker(ServiceMocker $serviceMocker);
 }

--- a/src/PSS/Behat/Symfony2MockerExtension/Extension.php
+++ b/src/PSS/Behat/Symfony2MockerExtension/Extension.php
@@ -19,7 +19,7 @@ class Extension implements ExtensionInterface
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/services'));
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/services'));
         $loader->load('core.xml');
     }
 

--- a/src/PSS/Behat/Symfony2MockerExtension/Extension.php
+++ b/src/PSS/Behat/Symfony2MockerExtension/Extension.php
@@ -19,7 +19,7 @@ class Extension implements ExtensionInterface
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/services'));
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/services'));
         $loader->load('core.xml');
     }
 

--- a/src/PSS/Behat/Symfony2MockerExtension/ServiceMocker.php
+++ b/src/PSS/Behat/Symfony2MockerExtension/ServiceMocker.php
@@ -4,8 +4,7 @@ namespace PSS\Behat\Symfony2MockerExtension;
 
 use Behat\Mink\Mink;
 use Behat\Symfony2Extension\Driver\KernelDriver;
-use Prophecy\Prophecy\ObjectProphecy;
-use PSS\SymfonyMockerContainer\DependencyInjection\MockerContainer;
+use PSS\SymfonyMockerContainer\DependencyInjection\MockerContainerInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 class ServiceMocker
@@ -34,7 +33,7 @@ class ServiceMocker
      * @param string $id               Service Id
      * @param string $classOrInterface Class or Interface name
      *
-     * @return ObjectProphecy
+     * @return object
      */
     public function mockService($id, $classOrInterface)
     {
@@ -42,7 +41,7 @@ class ServiceMocker
     }
 
     /**
-     * @return MockerContainer
+     * @return MockerContainerInterface
      * @throws \LogicException when used with not supported driver or container cannot create mocks
      */
     public function getMockerContainer()
@@ -50,7 +49,7 @@ class ServiceMocker
         if ($this->isKernelDriverUsed()) {
             $container = $this->kernel->getContainer();
 
-            if (!$container instanceof MockerContainer) {
+            if (!$container instanceof MockerContainerInterface) {
                 throw new \LogicException('Container is not able to mock the services');
             }
 
@@ -71,25 +70,6 @@ class ServiceMocker
     }
 
     /**
-     * @param string $serviceId
-     */
-    public function verifyServiceExpectationsById($serviceId)
-    {
-        $container = $this->getMockerContainer();
-        $service   = $container->get($serviceId);
-
-        $this->verifyServiceExpectations($service);
-    }
-
-    /**
-     * @param ObjectProphecy $service
-     */
-    public function verifyServiceExpectations(ObjectProphecy $service)
-    {
-        $service->checkProphecyMethodsPredictions();
-    }
-
-    /**
      * @return null
      */
     public function verifyPendingExpectations()
@@ -101,9 +81,17 @@ class ServiceMocker
         $container      = $this->getMockerContainer();
         $mockedServices = $container->getMockedServices();
 
-        foreach ($mockedServices as $id => $service) {
-            $this->verifyServiceExpectations($service);
+        foreach (array_keys($mockedServices) as $id) {
+            $this->verifyServiceExpectationsById($id);
             $container->unmock($id);
         }
+    }
+
+    /**
+     * @param string $serviceId
+     */
+    public function verifyServiceExpectationsById($serviceId)
+    {
+        $this->getMockerContainer()->verifyServiceExpectationsById($serviceId);
     }
 }

--- a/src/PSS/Behat/Symfony2MockerExtension/ServiceMocker.php
+++ b/src/PSS/Behat/Symfony2MockerExtension/ServiceMocker.php
@@ -4,6 +4,7 @@ namespace PSS\Behat\Symfony2MockerExtension;
 
 use Behat\Mink\Mink;
 use Behat\Symfony2Extension\Driver\KernelDriver;
+use Prophecy\Prophecy\ObjectProphecy;
 use Prophecy\Prophet;
 use PSS\SymfonyMockerContainer\DependencyInjection\MockerContainer;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -83,9 +84,9 @@ class ServiceMocker
     /**
      * @param Prophet $service
      */
-    public function verifyServiceExpectations(Prophet $service)
+    public function verifyServiceExpectations(ObjectProphecy $service)
     {
-        $service->checkPredictions();
+        $service->checkProphecyMethodsPredictions();
     }
 
     /**

--- a/src/PSS/Behat/Symfony2MockerExtension/ServiceMocker.php
+++ b/src/PSS/Behat/Symfony2MockerExtension/ServiceMocker.php
@@ -5,7 +5,6 @@ namespace PSS\Behat\Symfony2MockerExtension;
 use Behat\Mink\Mink;
 use Behat\Symfony2Extension\Driver\KernelDriver;
 use Prophecy\Prophecy\ObjectProphecy;
-use Prophecy\Prophet;
 use PSS\SymfonyMockerContainer\DependencyInjection\MockerContainer;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -32,11 +31,14 @@ class ServiceMocker
     }
 
     /**
-     * @return \Prophecy\Prophet
+     * @param string $id               Service Id
+     * @param string $classOrInterface Class or Interface name
+     *
+     * @return ObjectProphecy
      */
-    public function mockService()
+    public function mockService($id, $classOrInterface)
     {
-        return call_user_func_array(array($this->getMockerContainer(), 'mock'), func_get_args());
+        return $this->getMockerContainer()->mock($id, $classOrInterface);
     }
 
     /**
@@ -70,8 +72,6 @@ class ServiceMocker
 
     /**
      * @param string $serviceId
-     *
-     * @throws ExpectationException
      */
     public function verifyServiceExpectationsById($serviceId)
     {
@@ -82,7 +82,7 @@ class ServiceMocker
     }
 
     /**
-     * @param Prophet $service
+     * @param ObjectProphecy $service
      */
     public function verifyServiceExpectations(ObjectProphecy $service)
     {


### PR DESCRIPTION
[SymfonyMockerContainer](https://github.com/PolishSymfonyCommunity/SymfonyMockerContainer) needs merging and tagging [PR4](https://github.com/PolishSymfonyCommunity/SymfonyMockerContainer/pull/4) as version 2.0 before merging this PR.
